### PR TITLE
SOLO-1781 | Changes to support creating a subscription through POST

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 zuora_client CHANGELOG
 ======================
 
+2.0.7-orm
+---------
+
+- Add deleter for `collect`, `invoice`, and `run_billing` to `POSTSubscriptionType`
+- Allow `renewal_term` in `POSTSubscriptionType` to be set to `None`
+
 2.0.6-orm
 ---------
 

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@
 from setuptools import setup, find_packages  # noqa: H301
 
 NAME = "zuora-client"
-VERSION = "2.0.6-orm"
+VERSION = "2.0.7-orm"
 # To install the library, run the following
 #
 # python setup.py install

--- a/zuora_client/models/post_subscription_type.py
+++ b/zuora_client/models/post_subscription_type.py
@@ -1090,7 +1090,10 @@ class POSTSubscriptionType(object):
         result = {}
 
         for attr, _ in six.iteritems(self.swagger_types):
-            value = getattr(self, attr)
+            try:
+                value = getattr(self, attr)
+            except AttributeError:
+                continue
             if isinstance(value, list):
                 result[attr] = list(map(
                     lambda x: x.to_dict() if hasattr(x, "to_dict") else x,

--- a/zuora_client/models/post_subscription_type.py
+++ b/zuora_client/models/post_subscription_type.py
@@ -198,7 +198,8 @@ class POSTSubscriptionType(object):
             self.notes = notes
         if renewal_setting is not None:
             self.renewal_setting = renewal_setting
-        self.renewal_term = renewal_term
+        if renewal_term is not None:
+            self.renewal_term = renewal_term
         if renewal_term_period_type is not None:
             self.renewal_term_period_type = renewal_term_period_type
         if run_billing is not None:
@@ -581,6 +582,10 @@ class POSTSubscriptionType(object):
 
         self._collect = collect
 
+    @collect.deleter
+    def collect(self):
+        del self._collect
+
     @property
     def contract_effective_date(self):
         """Gets the contract_effective_date of this POSTSubscriptionType.  # noqa: E501
@@ -720,6 +725,10 @@ class POSTSubscriptionType(object):
         """
 
         self._invoice = invoice
+
+    @invoice.deleter
+    def invoice(self):
+        del self._invoice
 
     @property
     def invoice_collect(self):
@@ -929,6 +938,10 @@ class POSTSubscriptionType(object):
         """
 
         self._run_billing = run_billing
+
+    @run_billing.deleter
+    def run_billing(self):
+        del self._run_billing
 
     @property
     def service_activation_date(self):


### PR DESCRIPTION
[SOLO-1781](https://intranet.oreilly.com/jira/browse/SOLO-1781)

What:
- Add deleter for `collect`, `invoice`, and `run_billing` to `POSTSubscriptionType`
- Allow `renewal_term` in `POSTSubscriptionType` to be set to `None`
- Bump version to `2.0.7-orm`
